### PR TITLE
Fix selected networks dropdown

### DIFF
--- a/src/components/claim/ClaimPortal.svelte
+++ b/src/components/claim/ClaimPortal.svelte
@@ -25,7 +25,11 @@
   }
 </script>
 
-<div class="container">
+<div
+  class={`container ${
+    (!$userAddress || loading === true || !$airdrops) && "alignContentCenter"
+  }`}
+>
   {#if $userAddress && loading === false && $airdrops}
     <div class="claimableRewardsContainer">
       <ClaimableRewards />
@@ -61,7 +65,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     min-height: calc(100vh - 300px);
   }
 
@@ -77,6 +81,10 @@
   .loading {
     font-size: var(--font-size-normal);
     color: var(--brand-grey-light);
+  }
+
+  .alignContentCenter {
+    justify-content: center;
   }
 
   @media only screen and (min-width: 660px) {

--- a/src/components/header/NetworkSelection.svelte
+++ b/src/components/header/NetworkSelection.svelte
@@ -22,13 +22,15 @@
 <div class="container">
   <span class="text"> Selected networks </span>
   <Tooltip icon={ChevronDown} align="end">
-    {#each JSON.parse(process.env.SUPPORTED_CHAIN_IDS) as chainId}
-      <NetworkItem
-        {chainId}
-        checked={true}
-        {onCheck}
-      />
-    {/each}
+    {#if $selectedNetworks}
+      {#each JSON.parse(process.env.SUPPORTED_CHAIN_IDS) as chainId}
+        <NetworkItem
+          {chainId}
+          checked={$selectedNetworks.find((id) => id === chainId) !== undefined}
+          {onCheck}
+        />
+      {/each}
+    {/if}
   </Tooltip>
 </div>
 

--- a/src/components/header/NetworkSelection.svelte
+++ b/src/components/header/NetworkSelection.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onMount } from "svelte";
   import { selectedNetworks } from "../../stores/web3";
   import { Tooltip } from "carbon-components-svelte";
   import ChevronDown from "carbon-icons-svelte/lib/ChevronDown.svelte";
@@ -13,6 +14,32 @@
       selectedNetworks.update(() => [...$selectedNetworks, value]);
     }
   }
+
+  onMount(() => {
+    if (!localStorage.getItem("SupportedChainIds")) {
+      localStorage.setItem(
+        "SupportedChainIds",
+        JSON.stringify(JSON.parse(process.env.SUPPORTED_CHAIN_IDS))
+      );
+    } else {
+      let localStorageSupportedChainIds = JSON.parse(
+        localStorage.getItem("SupportedChainIds")
+      );
+      let envSupportedChainIds = JSON.parse(process.env.SUPPORTED_CHAIN_IDS);
+      if (
+        envSupportedChainIds.length != localStorageSupportedChainIds.length ||
+        envSupportedChainIds.every(function (element, index) {
+          return element !== localStorageSupportedChainIds[index];
+        })
+      ) {
+        selectedNetworks.update(() => envSupportedChainIds);
+        localStorage.setItem(
+          "SupportedChainIds",
+          JSON.stringify(envSupportedChainIds)
+        );
+      }
+    }
+  });
 
   $: if ($selectedNetworks) {
     localStorage.setItem("selectedNetworks", JSON.stringify($selectedNetworks));

--- a/src/stores/airdrops.js
+++ b/src/stores/airdrops.js
@@ -69,8 +69,7 @@ export const updateClaimablesFromAirdrop = async (airdropData, chainId, address,
 }
 
 export const updateAllClaimables = async (airdropData, selectedNetworks, userAddress, rewards) => {
-    const filteredChains = JSON.parse(process.env.SUPPORTED_CHAIN_IDS).filter(x => selectedNetworks.indexOf(x) >= 0);
-    await Promise.all(filteredChains.map(async function(chainId) {
+    await Promise.all(JSON.parse(process.env.SUPPORTED_CHAIN_IDS).map(async function(chainId) {
         if( airdropData[chainId] ) {
             await updateClaimablesFromAirdrop(airdropData, chainId, userAddress, rewards);
         } else {

--- a/src/stores/web3.js
+++ b/src/stores/web3.js
@@ -8,7 +8,7 @@ export let web3Provider = writable("");
 export let networkSigner = writable("");
 export let connectedChainId = writable("");
 export let web3 = writable("");
-export let selectedNetworks = writable([]);
+export let selectedNetworks = writable(localStorage.getItem("selectedNetworks") ? JSON.parse(localStorage.getItem("selectedNetworks")): []);
 export let jsonRPCProvider = writable({});
 export let isWalletConnectModalOpen = writable(false)
 


### PR DESCRIPTION
Fixes #148.

Changes proposed in this PR:

- [x] Make select network checkbox deselected on refresh if deselected previously
- [x] Get claimable rewards for all networks even if they are not part of selected chainIds to make rewards visible on reselect an deselected network
- [x] If env variables supported chainIds changes, update local storage