### PR TITLE
Added logic to calculate average lock.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ INFURA_KEY = 01SAMPLE9234KEY
 // chain where ve contracts are deployed - 8996 is development
 VE_SUPPORTED_CHAINID = 8996
 
+SUBGRAPH_API = https://v4.subgraph.rinkeby.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph
+
 // you can get the following addresses from barge @ address.json to develop locally
 VE_OCEAN_CONTRACT = 0x...
 VE_ALLOCATE_CONTRACT = 0x...

--- a/src/stores/subgraph.js
+++ b/src/stores/subgraph.js
@@ -1,3 +1,3 @@
 import { writable } from "svelte/store";
 
-export let veOceanSummary = writable(undefined);
+export let veTotalLocked = writable(undefined);

--- a/src/utils/dataVeOCEAN.js
+++ b/src/utils/dataVeOCEAN.js
@@ -1,8 +1,0 @@
-import { gql } from "apollo-boost";
-
-export const TOTAL_LOCKED = gql`{
-  veOCEANs(first:1000) {
-    id
-    lockedAmount
-  }
-}`;

--- a/src/utils/subgraph.js
+++ b/src/utils/subgraph.js
@@ -1,0 +1,15 @@
+import { gql } from "apollo-boost";
+
+export const TOTAL_LOCKED = gql`{
+    veOCEANs(first:1000) {
+      id
+      lockedAmount
+    }
+}`;
+
+export const DEPOSITS = gql`{
+    veDeposits(first:1000) {
+      timestamp
+      unlockTime
+    }
+}`


### PR DESCRIPTION
averageLock = sum(moment.diff(unlockTime - timestamp, 'days')) / totalLocks

Gets total number of days that users have locked for, and then divides by total number of locks.
Does not use mean or other statistical methods.

![Screenshot from 2022-09-29 11-54-37](https://user-images.githubusercontent.com/69865342/193118401-c77b609e-ade0-4ffc-9274-98e07ba60c3c.png)
