### PR TITLE
Renamed and reorganized navbar.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -223,10 +223,10 @@
   <WalletConnectModal />
   <main>
     <Header />
-    <Route path="/datafarming" primary={false}>
+    <Route path="/activerewards" primary={false}>
       <ClaimPortal />
     </Route>
-    <Route path="/activerewards" primary={false}>
+    <Route path="/datafarming" primary={false}>
       <DataPortal />
     </Route>
     <Route path="/veocean" primary={false}>

--- a/src/components/claim/ClaimRewardsVeDF.svelte
+++ b/src/components/claim/ClaimRewardsVeDF.svelte
@@ -153,7 +153,7 @@
     metrics={[{ name: "allocated", value: `${$totalUserAllocation}%` }]}
     showRedirectLink={(!$oceanUnlockDate || $totalUserAllocation <= 0) &&
       $dfClaimables <= 0}
-    redirectLink={{ text: "Set allocations", url: "activerewards" }}
+    redirectLink={{ text: "Set allocations", url: "datafarming" }}
     distributedAmount={roundInfo?.active}
     loading={claiming === "DF_REWARDS"}
     onClick={onClaimDfRewards}

--- a/src/components/header/Header.svelte
+++ b/src/components/header/Header.svelte
@@ -28,11 +28,11 @@
       <li class:active={$location.pathname === "/veocean"}>
         <Link to="/veocean" class="link">veOCEAN</Link>
       </li>
-      <li class:active={$location.pathname === "/activerewards"}>
-        <Link to="/activerewards" class="link">ACTIVE REWARDS</Link>
-      </li>
       <li class:active={$location.pathname === "/datafarming"}>
-        <Link to="/datafarming" class="link">DATA FARMING</Link>
+        <Link to="/datafarming" class="link">FARMS</Link>
+      </li>
+      <li class:active={$location.pathname === "/activerewards"}>
+        <Link to="/activerewards" class="link">REWARDS</Link>
       </li>
       <li class:active={false}>
         <a href={aboutURL} target="_blank" class="link">ABOUT</a>


### PR DESCRIPTION
Fixes #448 

1. Nav items renamed:
Data Farming => Farms
Rewards => Rewards

2. Nav items reordered:
The natural UX flow is (1) Lock => (2) Allocate => (3) Earn Rewards