### PR TITLE
Reconcile usd ocean streams

### DIFF
--- a/src/components/claim/ClaimPortal.svelte
+++ b/src/components/claim/ClaimPortal.svelte
@@ -21,6 +21,7 @@
   import { oceanUnlockDate } from "../../stores/veOcean";
   import { getRate } from "../../utils/market_rates";
   import * as streamsData from "../../utils/metadata/rewards/streams.json"
+  import { onMount } from "svelte";
 
   let loading = false;
   let veBalance = 0.0;
@@ -41,7 +42,7 @@
     
     // Update curEpoch rewards
     curEpoch.streams[1].substreams[0].rewards = adjustedVolumeDFReward;
-    curEpoch.streams[1].substreams[1].amountUSD = curEpoch.streams[1].substreams[1].rewards;
+    curEpoch.streams[1].substreams[1].rewardsUSD = curEpoch.streams[1].substreams[1].rewards;
     curEpoch.streams[1].substreams[1].rewards = challengeDFReward;
 
     // Update streams with rewards from curEpoch
@@ -50,18 +51,15 @@
         stream.rewards = curEpoch?.streams[indexStream]?.rewards;
         stream.substreams.forEach((substream, indexSubstream) => {
           substream.rewards = curEpoch.streams[indexStream].substreams[indexSubstream].rewards;
-          substream.amountUSD = substream.showUSD ? curEpoch.streams[indexStream].substreams[indexSubstream].amountUSD : 0;
+          substream.rewardsUSD = substream.showUSD ? curEpoch.streams[indexStream].substreams[indexSubstream].rewardsUSD : 0;
         });
         return stream; // return the updated stream
     });
 
     streams = modifiedStreams;
   }
-  populateStreamsWithRewardsFromCurrentEpoch();
-
 
   async function initClaimables() {
-
     if (!userAddress || !oceanUnlockDate) {
       veClaimables.set(0);
       dfClaimables.set(0);
@@ -95,6 +93,10 @@
   $: if ($userAddress && $connectedChainId) {
     initClaimables();
   }
+
+  onMount(() => {
+    populateStreamsWithRewardsFromCurrentEpoch();
+  })
 </script>
 
 <div class={`container`}>

--- a/src/components/claim/ClaimPortal.svelte
+++ b/src/components/claim/ClaimPortal.svelte
@@ -19,6 +19,7 @@
   import moment from "moment";
   import { getEpoch } from "../../utils/epochs";
   import { oceanUnlockDate } from "../../stores/veOcean";
+  import { getRate } from "../../utils/market_rates";
   import * as streamsData from "../../utils/metadata/rewards/streams.json"
 
   let loading = false;
@@ -27,18 +28,37 @@
   let canClaimDF = true;
   const now = moment.utc();
   let curEpoch = getEpoch(now);
-  let streams = streamsData.default.streams
+  let streams = null;
 
-  function populateStreamsWithRewardsFromCurrentEpoch(){
-    streams?.forEach((stream,indexStream) => {
-      if(!curEpoch?.streams) return
-      stream.rewards = curEpoch?.streams[indexStream]?.rewards
-      stream.substreams.forEach((substream, indexSubstream) => {
-        substream.rewards = curEpoch.streams[indexStream].substreams[indexSubstream].rewards
-      })
-    })
+  async function populateStreamsWithRewardsFromCurrentEpoch(){
+    // Calculate adjusted rewards for current epoch
+    const fxRate = await getRate('OCEAN', 'ocean-protocol');
+    const challengeDFReward = Math.round(
+      // TODO - Fix Magic Numbers
+      curEpoch.streams[1].substreams[1].rewards / fxRate, 2
+    );
+    const adjustedVolumeDFReward = curEpoch.streams[1].rewards - challengeDFReward;
+    
+    // Update curEpoch rewards
+    curEpoch.streams[1].substreams[0].rewards = adjustedVolumeDFReward;
+    curEpoch.streams[1].substreams[1].amountUSD = curEpoch.streams[1].substreams[1].rewards;
+    curEpoch.streams[1].substreams[1].rewards = challengeDFReward;
+
+    // Update streams with rewards from curEpoch
+    const modifiedStreams = streamsData.default.streams.map((stream, indexStream) => {
+        if(!curEpoch?.streams) return stream; // return the original stream if there is no current epoch
+        stream.rewards = curEpoch?.streams[indexStream]?.rewards;
+        stream.substreams.forEach((substream, indexSubstream) => {
+          substream.rewards = curEpoch.streams[indexStream].substreams[indexSubstream].rewards;
+          substream.amountUSD = substream.showUSD ? curEpoch.streams[indexStream].substreams[indexSubstream].amountUSD : 0;
+        });
+        return stream; // return the updated stream
+    });
+
+    streams = modifiedStreams;
   }
-  populateStreamsWithRewardsFromCurrentEpoch()
+  populateStreamsWithRewardsFromCurrentEpoch();
+
 
   async function initClaimables() {
 
@@ -80,7 +100,9 @@
 <div class={`container`}>
   <RewardOverview roundInfo={curEpoch} />
   <Features />
-  <ClaimRewards {canClaimVE} {canClaimDF} streams={streams}/>
+  {#if streams !== null}
+    <ClaimRewards {canClaimVE} {canClaimDF} streams={streams}/>
+  {/if}
   <EpochHistory />
 </div>
 

--- a/src/components/claim/Substream.svelte
+++ b/src/components/claim/Substream.svelte
@@ -9,13 +9,20 @@
     export let rewards = 0;
     export let apy;
     export let metric = {};
-    export let action = {}
+    export let action = {};
+    export let showUSD = false;
+    export let amountUSD = 0.0;
 </script>
-  
+
 <div class="container">
     <div class="title">
         <div class="titleSection">
-            <h4>{`${title} - ${availableRewards} OCEAN`}</h4>
+            {#if showUSD === true}
+                <h4>{`${title} - ${availableRewards} OCEAN - (${amountUSD} USD)`}</h4>
+            {:else}
+                <h4>{`${title} - ${availableRewards} OCEAN`}</h4>
+            {/if}
+            
             {#if apy}
                 <span class="apy">{apy.value}</span>
             {/if}

--- a/src/components/claim/Substream.svelte
+++ b/src/components/claim/Substream.svelte
@@ -6,23 +6,17 @@
     export let title;
     export let description;
     export let availableRewards = 0;
+    export let availableRewardsUSD = 0;
     export let rewards = 0;
     export let apy;
     export let metric = {};
     export let action = {};
-    export let showUSD = false;
-    export let amountUSD = 0.0;
 </script>
 
 <div class="container">
     <div class="title">
         <div class="titleSection">
-            {#if showUSD === true}
-                <h4>{`${title} - ${availableRewards} OCEAN - (${amountUSD} USD)`}</h4>
-            {:else}
-                <h4>{`${title} - ${availableRewards} OCEAN`}</h4>
-            {/if}
-            
+            <h4>{`${title} - ${availableRewards} OCEAN ${availableRewardsUSD ? `- (${availableRewardsUSD} USD)` : ''}`}</h4>
             {#if apy}
                 <span class="apy">{apy.value}</span>
             {/if}

--- a/src/components/common/ClaimItem.svelte
+++ b/src/components/common/ClaimItem.svelte
@@ -31,6 +31,8 @@
         action={substream.action}
         metric={substream.metric}
         apy={substream?.apy}
+        showUSD={substream.showUSD}
+        amountUSD={substream.amountUSD}
       />
     {/each}
   {/if}

--- a/src/components/common/ClaimItem.svelte
+++ b/src/components/common/ClaimItem.svelte
@@ -27,12 +27,11 @@
       <Substream 
         title={substream.name}
         availableRewards={substream.rewards}
+        availableRewardsUSD={substream.rewardsUSD}
         description={substream.description}
         action={substream.action}
         metric={substream.metric}
         apy={substream?.apy}
-        showUSD={substream.showUSD}
-        amountUSD={substream.amountUSD}
       />
     {/each}
   {/if}

--- a/src/utils/market_rates.js
+++ b/src/utils/market_rates.js
@@ -1,0 +1,25 @@
+export const getRate = async(bnb_symbol, cg_symbol) => {
+    let rate = await getBinanceRate(bnb_symbol);
+    if (rate !== null) {
+        return rate;
+    }
+
+    rate = await getCoingeckoRate(cg_symbol);
+    if (rate !== null) {
+        return rate;
+    }
+
+    return null;
+}
+
+export const getBinanceRate = async (token_symbol) => {
+    const response = await fetch(`https://api.binance.com/api/v3/ticker/price?symbol=${token_symbol}USDT`);
+    const data = await response.json();
+    return parseFloat(data.price);
+}
+
+export const getCoingeckoRate = async (tokenId) => {
+    const response = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${tokenId}&vs_currencies=usd`);
+    const data = await response.json();
+    return data[tokenId].usd;
+}

--- a/src/utils/metadata/epochs/epochs.json
+++ b/src/utils/metadata/epochs/epochs.json
@@ -804,7 +804,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -832,7 +832,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -860,7 +860,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -888,7 +888,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -916,7 +916,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -944,7 +944,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -972,7 +972,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -1000,7 +1000,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -1028,7 +1028,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -1056,7 +1056,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -1084,7 +1084,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -1112,7 +1112,7 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 75000
           }
         ]
       }
@@ -1140,11 +1140,11 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 1
           },
           {
             "name": "Challenge",
-            "rewards": 10000
+            "rewards": 1250
           }
         ]
       }
@@ -1172,11 +1172,11 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 1
           },
           {
             "name": "Challenge",
-            "rewards": 10000
+            "rewards": 1250
           }
         ]
       }
@@ -1204,11 +1204,12 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 1
           },
           {
             "name": "Challenge",
-            "rewards": 10000
+            "rewards": 1250,
+            "currency": "USDT"
           }
         ]
       }
@@ -1236,11 +1237,11 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 1
           },
           {
             "name": "Challenge",
-            "rewards": 10000
+            "rewards": 1250
           }
         ]
       }
@@ -1268,11 +1269,11 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 50000
+            "rewards": 1
           },
           {
             "name": "Challenge",
-            "rewards": 10000
+            "rewards": 1250
           }
         ]
       }

--- a/src/utils/metadata/rewards/streams.json
+++ b/src/utils/metadata/rewards/streams.json
@@ -7,7 +7,7 @@
         {
           "name": "veOCEAN",
           "rewards": 0,
-          "description": "Earn by locking OCEAN into veOCEAN Earn by locking OCEAN into veOCEAN",
+          "description": "Earn rewards by locking OCEAN and holding veOCEAN. The longer you hold, the more you earn.",
           "action": {
             "text": "Get veOCEAN",
             "location": "/veocean"
@@ -26,7 +26,7 @@
         {
           "name": "Volume DF",
           "rewards": 0,
-          "description": "Earn by allocating veOCEAN to high-DCV assets; or delegating veOCEAN to others.",
+          "description": "Earn rewards by allocating veOCEAN to high-DCV assets; or delegating veOCEAN to market curators.",
           "action": {
             "text": "Set allocation",
             "location": "/datafarming"
@@ -37,9 +37,9 @@
           }
         },
         {
-          "name": "Challenge",
+          "name": "Challenge DF",
           "rewards": 0,
-          "description": "Earn by doing Contestant actions (submit predictions once a week to the Predict-ETH Data Challenge).",
+          "description": "Earn rewards by participating and submitting predictions to the weekly Predict-ETH challenge.",
           "action": {
             "text": "Participate",
             "location": "/veocean"
@@ -47,7 +47,8 @@
           "metric": {
             "name": "completed",
             "value": "0"
-          }
+          },
+          "showUSD": true
         }
       ]
     }


### PR DESCRIPTION
Fixes #586 
- Structures streams & epoch file such that the required parameters exist
- Recalculates rewards by taking ChallengeDF rewards from the top,
- Reports USD equivalent values wherever appropriate (ChallengeDF only right now)

Does not fix:
- Broad usage of magic numbers to index passive/active/other rewards (address in separate issue)