### PR TITLE
Update ChallengeDF hooks

### DIFF
--- a/src/components/challenges/ActiveCard.svelte
+++ b/src/components/challenges/ActiveCard.svelte
@@ -2,13 +2,19 @@
   import Card from "../common/Card.svelte"
   import ActiveCTA from './ActiveCTA.svelte';
   import { getUpcomingFirstWednesdayOfTheMonth } from '../../utils/epochs.js';
-  
+  import moment from "moment";
+  import { getEpoch } from "../../utils/epochs";
+
   let title = "Active Challenges";
   let description = "Crunch some code and participate in the active data challenge. Data Farming challenges are a substream of Ocean Protocol Active Rewards, running over periods of 1 week. You can claim your prize in the Rewards page.";
+  
+  const now = moment.utc();
+  let curEpoch = getEpoch(now);
+
   let challengeDetails = {
-    bannerTitle: 'Predict-ETH Round 8',
+    bannerTitle: `Challenge DF`,
     challengeDescription: 'Predict the price of Ethereum',
-    reward: '$2500 Rewards',
+    reward: `${curEpoch.streams[1].substreams[1].rewards} OCEAN in Rewards`,
     buttonText: 'PARTICIPATE',
     deadlineText: 'Enter before ' + getUpcomingFirstWednesdayOfTheMonth().format('DD MMM YYYY'),
     url: 'https://github.com/oceanprotocol/predict-eth/blob/main/challenges/challenge-df.md'

--- a/src/components/claim/ClaimPortal.svelte
+++ b/src/components/claim/ClaimPortal.svelte
@@ -31,26 +31,12 @@
   let streams = null;
 
   async function populateStreamsWithRewardsFromCurrentEpoch(){
-    // Calculate adjusted rewards for current epoch
-    const fxRate = await getRate('OCEAN', 'ocean-protocol');
-    const challengeDFReward = Math.round(
-      // TODO - Fix Magic Numbers
-      curEpoch.streams[1].substreams[1].rewards / fxRate, 2
-    );
-    const adjustedVolumeDFReward = curEpoch.streams[1].rewards - challengeDFReward;
-    
-    // Update curEpoch rewards
-    curEpoch.streams[1].substreams[0].rewards = adjustedVolumeDFReward;
-    curEpoch.streams[1].substreams[1].rewardsUSD = curEpoch.streams[1].substreams[1].rewards;
-    curEpoch.streams[1].substreams[1].rewards = challengeDFReward;
-
     // Update streams with rewards from curEpoch
     const modifiedStreams = streamsData.default.streams.map((stream, indexStream) => {
         if(!curEpoch?.streams) return stream; // return the original stream if there is no current epoch
         stream.rewards = curEpoch?.streams[indexStream]?.rewards;
         stream.substreams.forEach((substream, indexSubstream) => {
           substream.rewards = curEpoch.streams[indexStream].substreams[indexSubstream].rewards;
-          substream.rewardsUSD = substream.showUSD ? curEpoch.streams[indexStream].substreams[indexSubstream].rewardsUSD : 0;
         });
         return stream; // return the updated stream
     });

--- a/src/components/claim/Substream.svelte
+++ b/src/components/claim/Substream.svelte
@@ -6,7 +6,6 @@
     export let title;
     export let description;
     export let availableRewards = 0;
-    export let availableRewardsUSD = 0;
     export let rewards = 0;
     export let apy;
     export let metric = {};
@@ -16,7 +15,7 @@
 <div class="container">
     <div class="title">
         <div class="titleSection">
-            <h4>{`${title} - ${availableRewards} OCEAN ${availableRewardsUSD ? `- (${availableRewardsUSD} USD)` : ''}`}</h4>
+            <h4>{`${title} - ${availableRewards} OCEAN`}</h4>
             {#if apy}
                 <span class="apy">{apy.value}</span>
             {/if}

--- a/src/components/common/ClaimItem.svelte
+++ b/src/components/common/ClaimItem.svelte
@@ -27,7 +27,6 @@
       <Substream 
         title={substream.name}
         availableRewards={substream.rewards}
-        availableRewardsUSD={substream.rewardsUSD}
         description={substream.description}
         action={substream.action}
         metric={substream.metric}

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -373,10 +373,10 @@ export async function loadDFChallengeResults() {
   } catch (error) {
     console.log("loadDataChallenges error:", error);
     dataChallenges.set([
-        [7, "$1250", "0x0abca", "$750", "0x0abcb", "$500", "0x0abc"],
-        [6, "$1250", "0x0abca", "$750", "0x0abcb", "$500", "0x0abc"],
-        [5, "$1250", "0x0abca", "$750", "0x0abcb", "$500", "0x0abc"],
-        [4, "$1250", "0x0abca", "$750", "0x0abcb", "$500", "0x0abc"]
+        [4, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
+        [3, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
+        [2, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
+        [1, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"]
     ]);
   }
 }

--- a/src/utils/metadata/epochs/epochs.json
+++ b/src/utils/metadata/epochs/epochs.json
@@ -1140,11 +1140,16 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 1
+            "rewards": 70000
           },
           {
             "name": "Challenge",
-            "rewards": 1250
+            "rewards": 5000,
+            "prizes": [
+              2500,
+              1500,
+              1000
+            ]
           }
         ]
       }
@@ -1172,11 +1177,16 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 1
+            "rewards": 70000
           },
           {
             "name": "Challenge",
-            "rewards": 1250
+            "rewards": 5000,
+            "prizes": [
+              2500,
+              1500,
+              1000
+            ]
           }
         ]
       }
@@ -1204,12 +1214,16 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 1
+            "rewards": 70000
           },
           {
             "name": "Challenge",
-            "rewards": 1250,
-            "currency": "USDT"
+            "rewards": 5000,
+            "prizes": [
+              2500,
+              1500,
+              1000
+            ]
           }
         ]
       }
@@ -1237,11 +1251,16 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 1
+            "rewards": 70000
           },
           {
             "name": "Challenge",
-            "rewards": 1250
+            "rewards": 5000,
+            "prizes": [
+              2500,
+              1500,
+              1000
+            ]
           }
         ]
       }
@@ -1269,11 +1288,16 @@
         "substreams": [
           {
             "name": "Volume DF",
-            "rewards": 1
+            "rewards": 70000
           },
           {
             "name": "Challenge",
-            "rewards": 1250
+            "rewards": 5000,
+            "prizes": [
+              2500,
+              1500,
+              1000
+            ]
           }
         ]
       }

--- a/src/utils/metadata/rewards/streams.json
+++ b/src/utils/metadata/rewards/streams.json
@@ -47,8 +47,7 @@
           "metric": {
             "name": "completed",
             "value": "0"
-          },
-          "showUSD": true
+          }
         }
       ]
     }


### PR DESCRIPTION
Fixes #593  
-[x] Table will point to the DF rounds
-[x] Table will show winners
-[x] There will not be a challenge name
-[x] The only name visible will be ChallengeDF
-[x] Prizes for upcoming ChallengeDF are coming from epochs.json
-[x] Epochs.json contains prizes for upcoming ChallengeDF rounds
-[x] Updated HistoricCard.svelte to proprely subscribe/unsubscribe from svelte store