### PR TITLE
Fix default challenge rewards mocked data

### DIFF
--- a/src/components/challenges/HistoryCard.svelte
+++ b/src/components/challenges/HistoryCard.svelte
@@ -41,7 +41,7 @@
   $: {
     if (!unsubscribe) { // Ensure we only subscribe once
       unsubscribe = dataChallenges.subscribe(async (value) => {
-        if( !value || value.length === 0 ) {
+        if( !value || value.length < 0 ) {
           await loadDFChallengeResults();
           
           const formattedResults = formatDFChallengeResults();
@@ -70,7 +70,7 @@
 <div class="container">
     <h2 class="title">{title}</h2>
         <div class="epochHistoryTableContainer">
-          {#if $dataChallenges.length > 0 && !loading}
+          {#if $dataChallenges.length >= 0 && !loading}
           <DataTable {headers} {rows} class="customTable">
             <svelte:fragment slot="cell-header" let:header>
               <div class="headerContainer">

--- a/src/components/challenges/HistoryCard.svelte
+++ b/src/components/challenges/HistoryCard.svelte
@@ -41,7 +41,7 @@
   $: {
     if (!unsubscribe) { // Ensure we only subscribe once
       unsubscribe = dataChallenges.subscribe(async (value) => {
-        if( !value || value.length < 0 ) {
+        if( !value ) {
           await loadDFChallengeResults();
           
           const formattedResults = formatDFChallengeResults();
@@ -70,7 +70,7 @@
 <div class="container">
     <h2 class="title">{title}</h2>
         <div class="epochHistoryTableContainer">
-          {#if $dataChallenges.length >= 0 && !loading}
+          {#if !$dataChallenges?.length >= 0 && !loading}
           <DataTable {headers} {rows} class="customTable">
             <svelte:fragment slot="cell-header" let:header>
               <div class="headerContainer">

--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -30,12 +30,7 @@ export async function loadDFChallengeResults() {
     dataChallenges.set(results);
   } catch (error) {
     console.log("loadDataChallenges error:", error);
-    dataChallenges.set([
-      [4, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
-      [3, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
-      [2, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
-      [1, "2500", "0x0abca", "1500", "0x0abcb", "1000", "0x0abc"],
-    ]);
+    dataChallenges.set([]);
   }
 }
 

--- a/src/stores/challenge.js
+++ b/src/stores/challenge.js
@@ -1,7 +1,7 @@
 import { writable } from "svelte/store";
 import { getChallengeRewards } from "../utils/rewards";
 
-export let dataChallenges = writable([]);
+export let dataChallenges = writable(undefined);
 export let userSubmittedChallenges = writable([]);
 
 export async function loadDFChallengeResults() {


### PR DESCRIPTION
When api request fails the challenge history data it's populated with some dummy data.
Return an empty array when request to get real data fails.